### PR TITLE
Quote and quiet tidyverse imports, fixes #9

### DIFF
--- a/kapitel/boolsche-operationen/kapitel.qmd
+++ b/kapitel/boolsche-operationen/kapitel.qmd
@@ -14,7 +14,7 @@ knitr::opts_knit$set(root.dir = "../../../dxi-beispiele")
 #| echo: false
 #| warning: false
 
-library(tidyverse)
+library("tidyverse")
 ```
 
 In R stehen die logischen Operationen als *binäre* Operatoren zur Verfügung, bzw. als Funktionen mit genau zwei Parametern. Diese logischen Operatoren sind vektorisiert. Es ist deshalb unnötig, logische Ausdrücke durch die Boole'sche Arithmetik zu ersetzen. Lediglich die Reihenfolge der Ausführung dieser Operatoren folgt der gleichen Regel wie die Arithmetik. 

--- a/kapitel/daten-beschreiben/kapitel.qmd
+++ b/kapitel/daten-beschreiben/kapitel.qmd
@@ -20,8 +20,11 @@ ie Funktionen zur Ermittlung der Kennzahlen von Datenrahmen werden durch die Bib
 ::: 
 
 ```{r}
-library(tidyverse)
-library(rstatix)
+#| echo: false
+#| warning: false
+
+library("tidyverse")
+library("rstatix")
 ```
 
 ## Universelle Kennwerte

--- a/kapitel/daten-formen/kapitel.qmd
+++ b/kapitel/daten-formen/kapitel.qmd
@@ -13,7 +13,10 @@ knitr::opts_knit$set(root.dir = "../../../dxi-beispiele/daten")
 Die Funktionen zum Formen von Datenrahmen werden durch die `tidyverse`-Bibliothek `tidyr` bereitgestellt. 
 
 ```{r}
-library(tidyverse)
+#| echo: false
+#| warning: false
+
+library("tidyverse")
 ```
 
 ## Transponieren

--- a/kapitel/daten-visualisieren/kapitel.qmd
+++ b/kapitel/daten-visualisieren/kapitel.qmd
@@ -17,7 +17,10 @@ In R erstellen wir Plots mit Hilfe der `ggplot2`-Funktionen. Anders als in Excel
 Als Erstes laden wir wie immer die `tidyverse`-Bibliothek, damit wir die ggplot-Funktionen und die Funktionsverkettung verwenden können.
 
 ```{r}
-library(tidyverse)
+#| echo: false
+#| warning: false
+
+library("tidyverse")
 ```
 
 <!-- 

--- a/kapitel/indizieren-gruppieren/kapitel.qmd
+++ b/kapitel/indizieren-gruppieren/kapitel.qmd
@@ -32,7 +32,8 @@ Intuitiv würde man beim Durchnummerieren an seine Sequenz von `1:n()` denken. D
 ```{r}
 #| echo: false
 #| warning: false
-library(tidyverse)
+
+library("tidyverse")
 ```
 
 ```{r}

--- a/kapitel/matrix-operationen/kapitel.qmd
+++ b/kapitel/matrix-operationen/kapitel.qmd
@@ -4,8 +4,11 @@ abstract: ""
 
 # Matrix-Operationen {#sec-chapter-matrix-operationen}
 
-```{r, include=FALSE}
-library(tidyverse)
+```{r}
+#| echo: false
+#| warning: false
+
+library("tidyverse")
 ```
 
 Matrizen sind in R 2-dimensionale *numerische* Vektoren, die aus Zeilen und Spalten bestehen. Die Anzahl der Zeilen und Spalten gibt die *Dimensionalität* der Matrix an. Allgemein wird von einer $m \times n$-Matrix gesprochen, wobei $m$ für die Anzahl der Zeilen und $n$ für die Anzahl der Spalten steht. 

--- a/kapitel/vektor-operationen/kapitel.qmd
+++ b/kapitel/vektor-operationen/kapitel.qmd
@@ -7,9 +7,11 @@ abstract: ""
 ## Work in Progress
 :::
 
-```{r, include=FALSE}
+```{r}
 #| echo: false
-library(tidyverse)
+#| warning: false
+
+library("tidyverse")
 ```
 
 **Vektoren** sind zusammengesetzte Datenstrukturen, die Werte vom gleichen Datentyp enthalten. In R bilden Vektoren die Basisstruktur für *alle Daten*. R unterscheidet zwischen Listen und Vektoren, wobei für Vektoren immer sichergestellt wird, dass alle Werte vom gleichen Datentyp sind.

--- a/kapitel/zeichenketten/kapitel.qmd
+++ b/kapitel/zeichenketten/kapitel.qmd
@@ -12,7 +12,10 @@ knitr::opts_knit$set(root.dir = "../../../dxi-beispiele/daten")
 Die Funktionen zum Formen von Datenrahmen werden durch die `tidyverse`-Bibliothek `tidyr` bereitgestellt. 
 
 ```{r}
-library(tidyverse)
+#| echo: false
+#| warning: false
+
+library("tidyverse")
 ```
 
 Bisher haben wir Zeichenketten als atomare Werte behandelt. In diesem Kapitel geht es die Operationen für Zeichenketten. 


### PR DESCRIPTION
Imports were not according to verbal recommendations. All imports are now quoted. 

Also added quarto attributes, so the repetetive and long output of tidyverse is no longer included. 

fixes #9